### PR TITLE
Bump base dependency to <5, test with GHC 8.10.4

### DIFF
--- a/dimensional-codata.cabal
+++ b/dimensional-codata.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                dimensional-codata
-version:             2014.0.0.2
+version:             2014.0.0.3
 synopsis:            CODATA Recommended Physical Constants with Dimensional Types
 homepage:            https://github.com/dmcclean/dimensional-codata/
 bug-reports:         https://github.com/dmcclean/dimensional-codata/issues/
@@ -14,7 +14,7 @@ maintainer:          douglas.mcclean@gmail.com
 category:            Physics
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.8.4
+tested-with:         GHC == 7.8.4, GHC == 7.10.1, GHC == 7.10.2, GHC == 8.8.4, GHC == 8.10.4
 
 description:
 
@@ -31,7 +31,7 @@ source-repository head
   location: https://github.com/dmcclean/dimensional-codata/
 
 library
-  build-depends:       base >=4.7 && <4.14,
+  build-depends:       base >=4.7 && <5,
                        dimensional >= 1.0,
                        numtype-dk >= 0.5 && < 1
   hs-source-dirs:      src

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-12.25
+resolver: lts-17.9
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
FYI I uploaded this one to hackage already. It wasn't building with GHC 8.10.

I think the risk of incremental changes to `base` breaking this simple package is small, so I bumped the `base` constraint to `<5`. I hope you don't mind, but I can tighten it down again if you prefer.